### PR TITLE
Add support for basic auth

### DIFF
--- a/ical2paleventfile.py
+++ b/ical2paleventfile.py
@@ -24,6 +24,12 @@ import datetime as dt
 from datetime import datetime
 from dateutil import tz
 import os
+import urllib
+from base64 import b64encode
+
+def basic_auth(username, password):
+  token = b64encode(f"{username}:{password}".encode('utf-8')).decode("ascii")
+  return f'Basic {token}'
 
 homedir = expanduser("~")
 
@@ -43,9 +49,14 @@ for section in parser.sections():
   print ("url: ",url)
   print ("pal: ",pal_file)
   print ("calendar name: ",calendarname)
+
+  parsed = urllib.parse.urlparse(url)
   
   http = urllib3.PoolManager()
-  response = http.request('GET', url)
+  headers = None
+  if parsed.username is not None and parsed.password is not None:
+    headers = { 'Authorization' : basic_auth(parsed.username, parsed.password) }
+  response = http.request('GET', url, headers=headers)
 
   c = Calendar(response.data.decode('utf-8'))
   


### PR DESCRIPTION
This adds support for HTTP Basic Auth in the ical URL. It's a bit hacky, but seems to works.

This fires if the `url` key in a config section has a value of the standard form
```
https://user:pass@example.com/foo.ics
```

with `user` and `pass` being the username and password, respectively. This does mean that the password is put into the config file in plain text, though.

My use-case is that I have my own radicale server set up, and I have put access to that behind auth.